### PR TITLE
fix ReadFormatCapacities

### DIFF
--- a/src/scsi/commands/read_format_capacities.rs
+++ b/src/scsi/commands/read_format_capacities.rs
@@ -14,6 +14,6 @@ pub struct ReadFormatCapacitiesCommand {
     #[overlay(bytes=7..=8)]
     pub allocation_length: u16,
 
-    #[overlay(bytes=11..=11, nested)]
+    #[overlay(bytes=9..=9, nested)]
     pub control: Control,
 }

--- a/src/scsi/mod.rs
+++ b/src/scsi/mod.rs
@@ -259,17 +259,16 @@ impl<'scsi, BD: BlockDevice> bulk_only_transport::Handler for BulkHandler<'scsi,
             }
             Command::ModeSense(_) => todo!(),
             Command::ReadFormatCapacities(ReadFormatCapacitiesCommand { .. }) => {
-                //let mut data = [0u8; 12];
-                //let _ = &mut data[0..4].copy_from_slice(&[
-                //    0x00, 0x00, 0x00, 0x08, // capacity list length
-                //]);
-                //let _ = &mut data[4..8].copy_from_slice(&u32::to_be_bytes(BLOCKS)); // number of blocks
-                //data[8] = 0x01; //unformatted media
-                //let block_length_be = u32::to_be_bytes(BLOCK_SIZE);
-                //data[9] = block_length_be[1];
-                //data[10] = block_length_be[2];
-                //data[11] = block_length_be[3];
-                todo!()
+                let max_lba = self.block_device.block_count();
+
+                let mut response = [0u8; 12];
+                response[3] = 0x08; // capacity list length
+                response[4..8].copy_from_slice(max_lba.to_be_bytes().as_slice());
+                response[9] = 0x02; // formatted media
+                response[10] = 0x02; // block size set to 512
+
+                writer.write_all(&response).await?;
+                Ok(())
             }
             _ => {
                 error!("invalid to-host command");

--- a/src/scsi/mod.rs
+++ b/src/scsi/mod.rs
@@ -260,12 +260,13 @@ impl<'scsi, BD: BlockDevice> bulk_only_transport::Handler for BulkHandler<'scsi,
             Command::ModeSense(_) => todo!(),
             Command::ReadFormatCapacities(ReadFormatCapacitiesCommand { .. }) => {
                 let max_lba = self.block_device.block_count();
+                let block_size = BD::BLOCK_BYTES as u32;
 
                 let mut response = [0u8; 12];
                 response[3] = 0x08; // capacity list length
                 response[4..8].copy_from_slice(max_lba.to_be_bytes().as_slice());
-                response[9] = 0x02; // formatted media
-                response[10] = 0x02; // block size set to 512
+                response[8] = 0x02; // formatted media
+                response[9..12].copy_from_slice(&block_size.to_be_bytes().as_slice()[1..]); // block size
 
                 writer.write_all(&response).await?;
                 Ok(())


### PR DESCRIPTION
Windows is using the Read Format Capacities Command (0x23). The size of the command was wrong in the scsi mod and the command itself was not implmented.

Windows is taking 3 attempts to get Read Format Capacities (with 5-10 seconds delay each), and after missing it moves on. This pull request makes the process faster (immediate detection instead of waiting for half a minute).